### PR TITLE
refactor: revert "use `usize` for indexing palette items instead of `u8`"

### DIFF
--- a/pmaker/src/parsers/xsd.rs
+++ b/pmaker/src/parsers/xsd.rs
@@ -703,7 +703,7 @@ fn map_stitches_data_into_stitches(
       fullstitches.push(FullStitch {
         x,
         y,
-        palindex: stitch_buffer[2] as usize,
+        palindex: stitch_buffer[2],
         kind: FullStitchKind::Full,
       });
       continue;
@@ -723,7 +723,7 @@ fn map_stitches_data_into_stitches(
         fullstitches.push(FullStitch {
           x,
           y,
-          palindex: small_stitch_buffer[palindex_index] as usize,
+          palindex: small_stitch_buffer[palindex_index],
           kind: FullStitchKind::Petite,
         })
       }
@@ -752,7 +752,7 @@ fn map_stitches_data_into_stitches(
         partstitches.push(PartStitch {
           x,
           y,
-          palindex: small_stitch_buffer[palindex_index] as usize,
+          palindex: small_stitch_buffer[palindex_index],
           direction,
           kind,
         })
@@ -888,7 +888,7 @@ fn read_joints<R: Read + Seek>(reader: &mut R, joints_count: u16) -> io::Result<
         let x = reader.read_u16::<LittleEndian>()? as f32 / 2.0;
         let y = reader.read_u16::<LittleEndian>()? as f32 / 2.0;
         reader.seek_relative(4)?;
-        let palindex = reader.read_u8()? as usize;
+        let palindex = reader.read_u8()?;
         reader.seek_relative(1)?;
         nodestitches.push(NodeStitch {
           x,
@@ -905,7 +905,7 @@ fn read_joints<R: Read + Seek>(reader: &mut R, joints_count: u16) -> io::Result<
         let y1 = reader.read_u16::<LittleEndian>()? as f32 / 2.0;
         let x2 = reader.read_u16::<LittleEndian>()? as f32 / 2.0;
         let y2 = reader.read_u16::<LittleEndian>()? as f32 / 2.0;
-        let palindex = reader.read_u8()? as usize;
+        let palindex = reader.read_u8()?;
         reader.seek_relative(1)?;
         let kind = if joint_kind == XsdJointKind::Back {
           LineStitchKind::Back
@@ -938,7 +938,7 @@ fn read_joints<R: Read + Seek>(reader: &mut R, joints_count: u16) -> io::Result<
 
       XsdJointKind::Special => {
         reader.seek_relative(2)?;
-        let palindex = reader.read_u8()? as usize;
+        let palindex = reader.read_u8()?;
         reader.seek_relative(4)?;
         let x = reader.read_u16::<LittleEndian>()? as f32 / 2.0;
         let y = reader.read_u16::<LittleEndian>()? as f32 / 2.0;
@@ -973,7 +973,7 @@ fn read_joints<R: Read + Seek>(reader: &mut R, joints_count: u16) -> io::Result<
           (rotation, flip)
         };
         reader.seek_relative(2)?;
-        let modindex = reader.read_u16::<LittleEndian>()? as usize;
+        let modindex = reader.read_u16::<LittleEndian>()? as u8;
         specialstitches.push(SpecialStitch {
           x,
           y,
@@ -988,7 +988,7 @@ fn read_joints<R: Read + Seek>(reader: &mut R, joints_count: u16) -> io::Result<
         reader.seek_relative(2)?;
         let x = reader.read_u16::<LittleEndian>()? as f32 / 2.0;
         let y = reader.read_u16::<LittleEndian>()? as f32 / 2.0;
-        let palindex = reader.read_u8()? as usize;
+        let palindex = reader.read_u8()?;
         reader.seek_relative(1)?;
         let rotated = matches!(reader.read_u16::<LittleEndian>()?, 90 | 270);
         nodestitches.push(NodeStitch {

--- a/pmaker/src/schemas/xsd.rs
+++ b/pmaker/src/schemas/xsd.rs
@@ -130,7 +130,7 @@ pub struct Symbols {
 pub struct FullStitch {
   pub x: f32,
   pub y: f32,
-  pub palindex: usize,
+  pub palindex: u8,
   pub kind: FullStitchKind,
 }
 
@@ -144,7 +144,7 @@ pub enum FullStitchKind {
 pub struct PartStitch {
   pub x: f32,
   pub y: f32,
-  pub palindex: usize,
+  pub palindex: u8,
   pub direction: PartStitchDirection,
   pub kind: PartStitchKind,
 }
@@ -165,7 +165,7 @@ pub enum PartStitchKind {
 pub struct LineStitch {
   pub x: (f32, f32),
   pub y: (f32, f32),
-  pub palindex: usize,
+  pub palindex: u8,
   pub kind: LineStitchKind,
 }
 
@@ -180,7 +180,7 @@ pub struct NodeStitch {
   pub x: f32,
   pub y: f32,
   pub rotated: bool,
-  pub palindex: usize,
+  pub palindex: u8,
   pub kind: NodeStitchKind,
 }
 
@@ -196,8 +196,8 @@ pub struct SpecialStitch {
   pub y: f32,
   pub rotation: u16,
   pub flip: (bool, bool),
-  pub palindex: usize,
-  pub modindex: usize,
+  pub palindex: u8,
+  pub modindex: u8,
 }
 
 #[derive(Debug, PartialEq)]

--- a/ursa/src/parsers/oxs.rs
+++ b/ursa/src/parsers/oxs.rs
@@ -286,7 +286,7 @@ fn read_full_stitches<R: io::BufRead>(reader: &mut Reader<R>) -> Result<Vec<Full
         full_stitches.push(FullStitch {
           x: attributes.get("x").unwrap().parse()?,
           y: attributes.get("y").unwrap().parse()?,
-          palindex: attributes.get("palindex").unwrap().parse::<usize>()? - 1,
+          palindex: attributes.get("palindex").unwrap().parse::<u8>()? - 1,
           kind: FullStitchKind::Full,
         });
       }
@@ -343,8 +343,8 @@ fn read_part_stitches<R: io::BufRead>(reader: &mut Reader<R>) -> Result<Vec<Part
           _ => panic!("Unknown part stitch kind"),
         };
 
-        let palindex1: usize = attributes.get("palindex1").unwrap().parse()?;
-        let palindex2: usize = attributes.get("palindex2").unwrap().parse()?;
+        let palindex1: u8 = attributes.get("palindex1").unwrap().parse()?;
+        let palindex2: u8 = attributes.get("palindex2").unwrap().parse()?;
 
         if palindex1 != 0 {
           let (x, y) = if direction_value == 1 { (x, y + 0.5) } else { (x, y) };
@@ -501,7 +501,7 @@ fn read_line_stitches<R: io::BufRead>(reader: &mut Reader<R>) -> Result<Vec<Line
             attributes.get("y1").unwrap().parse()?,
             attributes.get("y2").unwrap().parse()?,
           ),
-          palindex: attributes.get("palindex").unwrap().parse::<usize>()? - 1,
+          palindex: attributes.get("palindex").unwrap().parse::<u8>()? - 1,
           kind: attributes.get("objecttype").unwrap().parse()?,
         });
       }
@@ -549,7 +549,7 @@ fn read_ornaments<R: io::BufRead>(reader: &mut Reader<R>) -> Result<(Vec<FullSti
 
         let x = attributes.get("x1").unwrap().parse()?;
         let y = attributes.get("y1").unwrap().parse()?;
-        let palindex = attributes.get("palindex").unwrap().parse::<usize>()? - 1;
+        let palindex: u8 = attributes.get("palindex").unwrap().parse::<u8>()? - 1;
         let kind = attributes.get("objecttype").unwrap();
 
         // Yes, the Ursa Software's OXS format uses the "quarter" stitch for petites.

--- a/ursa/src/schemas/oxs.rs
+++ b/ursa/src/schemas/oxs.rs
@@ -66,7 +66,7 @@ impl std::str::FromStr for Symbol {
 pub struct FullStitch {
   pub x: f32,
   pub y: f32,
-  pub palindex: usize,
+  pub palindex: u8,
   pub kind: FullStitchKind,
 }
 
@@ -80,7 +80,7 @@ pub enum FullStitchKind {
 pub struct PartStitch {
   pub x: f32,
   pub y: f32,
-  pub palindex: usize,
+  pub palindex: u8,
   pub direction: PartStitchDirection,
   pub kind: PartStitchKind,
 }
@@ -119,7 +119,7 @@ pub enum PartStitchKind {
 pub struct LineStitch {
   pub x: (f32, f32),
   pub y: (f32, f32),
-  pub palindex: usize,
+  pub palindex: u8,
   pub kind: LineStitchKind,
 }
 
@@ -154,7 +154,7 @@ impl std::str::FromStr for LineStitchKind {
 pub struct NodeStitch {
   pub x: f32,
   pub y: f32,
-  pub palindex: usize,
+  pub palindex: u8,
   pub kind: NodeStitchKind,
 }
 


### PR DESCRIPTION
This reverts commit 730dfe19bbe20463ed3c3f9df0d9ef5d34c2a118.